### PR TITLE
Fix build and update palacaze Sigslot library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 # dependencies
-find_package(Boost COMPONENTS signals system thread REQUIRED)
+find_package(Boost COMPONENTS signals system chrono filesystem thread REQUIRED)
 find_package(Threads)
 
 # project definition
@@ -36,8 +36,8 @@ add_executable(bench
     benchmark/cpp/benchmark_psg.cpp
     benchmark/cpp/benchmark_pss.cpp
     benchmark/cpp/benchmark_pss_st.cpp
-    benchmark/cpp/benchmark_spp.cpp
     benchmark/cpp/benchmark_sss.cpp
+    benchmark/cpp/benchmark_vdk.cpp
     benchmark/cpp/benchmark_wnk.cpp
     benchmark/cpp/benchmark_wsg.cpp
     benchmark/cpp/benchmark_yas.cpp
@@ -58,5 +58,5 @@ add_executable(bench
 set_target_properties(bench PROPERTIES CXX_EXTENSIONS NO)
 target_include_directories(bench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(bench PRIVATE  "-fdiagnostics-color=always")
-target_link_libraries(bench Boost::system Boost::signals Threads::Threads)
+target_link_libraries(bench Boost::system Boost::signals Boost::chrono Boost::filesystem Threads::Threads)
 

--- a/benchmark/hpp/benchmark_cps.hpp
+++ b/benchmark/hpp/benchmark_cps.hpp
@@ -23,7 +23,7 @@ class Cps : public cppsignal::slot_tracker
     template <typename Subject, typename Foo>
     static void connect_method(Subject& subject, Foo& foo)
     {
-        subject.connect<Foo, &Foo::handler>(foo);
+        subject.template connect<Foo, &Foo::handler>(foo);
     }
     template <typename Subject>
     static void emit_method(Subject& subject, Rng& rng)

--- a/benchmark/hpp/benchmark_cps_st.hpp
+++ b/benchmark/hpp/benchmark_cps_st.hpp
@@ -23,7 +23,7 @@ class Cps_st : public cppsignal_st::slot_tracker
     template <typename Subject, typename Foo>
     static void connect_method(Subject& subject, Foo& foo)
     {
-        subject.connect<Foo, &Foo::handler>(foo);
+        subject.template connect<Foo, &Foo::handler>(foo);
     }
     template <typename Subject>
     static void emit_method(Subject& subject, Rng& rng)

--- a/benchmark/hpp/benchmark_nss.hpp
+++ b/benchmark/hpp/benchmark_nss.hpp
@@ -18,7 +18,7 @@ class Nss : public Nano_Deprecated::Observer
     template <typename Subject, typename Foo>
     static void connect_method(Subject& subject, Foo& foo)
     {
-        subject.connect<Foo, &Foo::handler>(foo);
+        subject.template connect<Foo, &Foo::handler>(foo);
     }
     template <typename Subject>
     static void emit_method(Subject& subject, Rng& rng)

--- a/benchmark/hpp/benchmark_nss_v2.hpp
+++ b/benchmark/hpp/benchmark_nss_v2.hpp
@@ -30,7 +30,7 @@ class Nss_v2 : public Nano::Observer<Mutex>
     template <typename Subject, typename Foo>
     static void connect_method(Subject& subject, Foo& foo)
     {
-        subject.connect<&Foo::handler>(foo);
+        subject.template connect<&Foo::handler>(foo);
     }
     template <typename Subject>
     static void emit_method(Subject& subject, Rng& rng)

--- a/benchmark/hpp/benchmark_nss_v2_st.hpp
+++ b/benchmark/hpp/benchmark_nss_v2_st.hpp
@@ -18,7 +18,7 @@ class Nss_v2_st : public Nano::Observer<>
     template <typename Subject, typename Foo>
     static void connect_method(Subject& subject, Foo& foo)
     {
-        subject.connect<&Foo::handler>(foo);
+        subject.template connect<&Foo::handler>(foo);
     }
     template <typename Subject>
     static void emit_method(Subject& subject, Rng& rng)

--- a/benchmark/hpp/benchmark_pss.hpp
+++ b/benchmark/hpp/benchmark_pss.hpp
@@ -43,6 +43,6 @@ class Pss
     static constexpr const char* C_LIB_SOURCE_URL = "https://github.com/palacaze/sigslot";
     static constexpr const char* C_LIB_FILE = "benchmark_pss";
     static constexpr const char* C_LIB_IS_HEADER_ONLY = "X";
-    static constexpr const char* C_LIB_DATA_STRUCTURE = "singly linked list";
+    static constexpr const char* C_LIB_DATA_STRUCTURE = "std::vector";
     static constexpr const char* C_LIB_IS_THREAD_SAFE = "X";
 };

--- a/benchmark/hpp/benchmark_pss_st.hpp
+++ b/benchmark/hpp/benchmark_pss_st.hpp
@@ -45,6 +45,6 @@ class Pss_st
     static constexpr const char* C_LIB_SOURCE_URL = "https://github.com/palacaze/sigslot";
     static constexpr const char* C_LIB_FILE = "benchmark_pss_st";
     static constexpr const char* C_LIB_IS_HEADER_ONLY = "X";
-    static constexpr const char* C_LIB_DATA_STRUCTURE = "singly linked list";
+    static constexpr const char* C_LIB_DATA_STRUCTURE = "std::vector";
     static constexpr const char* C_LIB_IS_THREAD_SAFE = "-";
 };

--- a/benchmark/lib/Montellese/cpp-signal/cpp-signal.h
+++ b/benchmark/lib/Montellese/cpp-signal/cpp-signal.h
@@ -366,13 +366,13 @@ public:
     template<typename... TEmitArgs>
     inline void emit(TEmitArgs&&... args)
     {
-      slot_tracker::call<connected_slot>(std::forward<TEmitArgs>(args)...);
+      slot_tracker::template call<connected_slot>(std::forward<TEmitArgs>(args)...);
     }
 
     template<typename TCollector, typename... TEmitArgs>
     inline void emit_collect(TCollector&& collector, TEmitArgs&&... args)
     {
-      slot_tracker::call_collect<connected_slot, TCollector>(std::forward<TCollector>(collector), std::forward<TEmitArgs>(args)...);
+      slot_tracker::template call_collect<connected_slot, TCollector>(std::forward<TCollector>(collector), std::forward<TEmitArgs>(args)...);
     }
 
     // callable object

--- a/benchmark/lib/NoAvailableAlias/nano-signal-slot-v2x/nano_observer.hpp
+++ b/benchmark/lib/NoAvailableAlias/nano-signal-slot-v2x/nano_observer.hpp
@@ -2,6 +2,7 @@
 
 #include <forward_list>
 #include <memory>
+#include <mutex>
 
 #include "nano_function.hpp"
 #include "nano_mutex.hpp"

--- a/benchmark/lib/NoAvailableAlias/nano-signal-slot-v2x/nano_signal_slot.hpp
+++ b/benchmark/lib/NoAvailableAlias/nano-signal-slot-v2x/nano_signal_slot.hpp
@@ -9,10 +9,10 @@ namespace Nano
 template <typename RT, typename Mutex = Noop_Mutex>
 class Signal;
 template <typename RT, typename Mutex, typename... Args>
-class Signal<RT(Args...), Mutex> final : public Observer<Mutex>
+class Signal<RT(Args...), Mutex> final : public ::Nano::Observer<Mutex>
 {
-    using Observer = Observer<Mutex>;
-    using Function = Function<RT(Args...)>;
+    using Observer = ::Nano::Observer<Mutex>;
+    using Function = ::Nano::Function<RT(Args...)>;
 
     template <typename T>
     void insert_sfinae(Delegate_Key const& key, typename T::Observer* instance)
@@ -148,13 +148,13 @@ class Signal<RT(Args...), Mutex> final : public Observer<Mutex>
     template <typename... Uref>
     void fire(Uref&&... args)
     {
-        Observer::for_each<Function>(std::forward<Uref>(args)...);
+        Observer::template for_each<Function>(std::forward<Uref>(args)...);
     }
 
     template <typename Accumulate, typename... Uref>
     void fire_accumulate(Accumulate&& accumulate, Uref&&... args)
     {
-        Observer::for_each_accumulate<Function, Accumulate>
+        Observer::template for_each_accumulate<Function, Accumulate>
             (std::forward<Accumulate>(accumulate), std::forward<Uref>(args)...);
     }
 };

--- a/benchmark/lib/i42output/include/neolib/memory.hpp
+++ b/benchmark/lib/i42output/include/neolib/memory.hpp
@@ -44,6 +44,7 @@
 #include <new>
 #include <stdexcept>
 #include <memory>
+#include <iostream>
 #include "detail_memory.hpp"
 
 namespace neolib

--- a/benchmark/lib/i42output/include/neolib/waitable_event.hpp
+++ b/benchmark/lib/i42output/include/neolib/waitable_event.hpp
@@ -39,6 +39,8 @@
 #include <stdexcept>
 #include <thread>
 #include <mutex>
+#include <vector>
+#include <condition_variable>
 #include "message_queue.hpp"
 #include "waitable.hpp"
 #include "variant.hpp"

--- a/benchmark/lib/i42output/src/async_thread.cpp
+++ b/benchmark/lib/i42output/src/async_thread.cpp
@@ -39,7 +39,7 @@
 namespace neolib
 {
 	async_thread::async_thread(const std::string& aName, bool aAttachToCurrentThread) : 
-		thread{ aName, aAttachToCurrentThread }, async_task{ static_cast<i_thread&>(*this) }
+		::neolib::thread{ aName, aAttachToCurrentThread }, async_task{ static_cast<i_thread&>(*this) }
 	{
 	}
 

--- a/benchmark/lib/palacaze/sigslot/signal.hpp
+++ b/benchmark/lib/palacaze/sigslot/signal.hpp
@@ -4,6 +4,8 @@
 #include <utility>
 #include <mutex>
 #include <atomic>
+#include <vector>
+#include <cassert>
 
 namespace sigslot {
 
@@ -81,8 +83,146 @@ constexpr bool is_callable_v = detail::is_callable<T..., L>::value;
 
 } // namespace trait
 
+template <typename, typename...>
+class signal_base;
 
 namespace detail {
+
+// noop mutex for thread-unsafe use
+struct null_mutex {
+    null_mutex() = default;
+    null_mutex(const null_mutex &) = delete;
+    null_mutex operator=(const null_mutex &) = delete;
+    null_mutex(null_mutex &&) = delete;
+    null_mutex operator=(null_mutex &&) = delete;
+
+    inline bool try_lock() noexcept { return true; }
+    inline void lock() noexcept {}
+    inline void unlock() noexcept {}
+};
+
+/**
+ * A simple copy on write container that will be used to improve slot lists
+ * access efficiency in a multithreaded context.
+ */
+template <typename T>
+class copy_on_write {
+    struct payload {
+        payload() = default;
+
+        template <typename... Args>
+        explicit payload(Args && ...args)
+            : value(std::forward<Args>(args)...)
+        {}
+
+        std::atomic<std::size_t> count{1};
+        T value;
+    };
+
+public:
+    using element_type = T;
+
+    copy_on_write()
+        : m_data(new payload)
+    {}
+
+    template <typename U>
+    copy_on_write(U && x, std::enable_if_t<!std::is_same<std::decay_t<U>, copy_on_write>{}>* = nullptr)
+        : m_data(new payload(std::forward<U>(x)))
+    {}
+
+    copy_on_write(const copy_on_write &x) noexcept
+        : m_data(x.m_data)
+    {
+        ++m_data->count;
+    }
+
+    copy_on_write(copy_on_write && x) noexcept
+        : m_data(x.m_data)
+    {
+        x.m_data = nullptr;
+    }
+
+    ~copy_on_write() {
+        if (m_data && (--m_data->count == 0))
+            delete m_data;
+    }
+
+    copy_on_write& operator=(const copy_on_write &x) noexcept {
+        return *this = copy_on_write(x);
+    }
+
+    copy_on_write& operator=(copy_on_write && x) noexcept  {
+        auto tmp = std::move(x);
+        swap(*this, tmp);
+        return *this;
+    }
+
+    element_type& write() {
+        if (!unique())
+            *this = copy_on_write(read());
+        return m_data->value;
+    }
+
+    const element_type& read() const noexcept {
+        return m_data->value;
+    }
+
+    friend inline void swap(copy_on_write &x, copy_on_write &y) noexcept {
+        using std::swap;
+        swap(x.m_data, y.m_data);
+    }
+
+private:
+    bool unique() const noexcept {
+        return m_data->count == 1;
+    }
+
+private:
+    payload *m_data;
+};
+
+/**
+ * Specializations for thread-safe code path
+ */
+template <typename T>
+const T& cow_read(T &v) {
+    return v;
+}
+
+template <typename T>
+const T& cow_read(copy_on_write<T> &v) {
+    return v.read();
+}
+
+template <typename T>
+T& cow_write(T &v) {
+    return v;
+}
+
+template <typename T>
+T& cow_write(copy_on_write<T> &v) {
+    return v.write();
+}
+
+/**
+ * std::make_shared instantiates a lot a templates, and makes both compilation time
+ * and executable size far bigger than they need to be. We offer a make_shared
+ * equivalent that will avoid most instantiations with the following tradeoffs:
+ * - Not exception safe,
+ * - Allocates a separate control block, and will thus make the code slower.
+ */
+#ifdef SIGSLOT_REDUCE_COMPILE_TIME
+template<typename B, typename D, typename ...Arg>
+inline std::shared_ptr<B> make_shared(Arg && ... arg) {
+    return std::shared_ptr<B>(static_cast<B*>(new D(std::forward<Arg>(arg)...)));
+}
+#else
+template<typename B, typename D, typename ...Arg>
+inline std::shared_ptr<B> make_shared(Arg && ... arg) {
+    return std::static_pointer_cast<B>(std::make_shared<D>(std::forward<Arg>(arg)...));
+}
+#endif
 
 /* slot_state holds slot type independent state, to be used to interact with
  * slots indirectly through connection and scoped_connection objects.
@@ -90,19 +230,34 @@ namespace detail {
 class slot_state {
 public:
     constexpr slot_state() noexcept
-        : m_connected(true),
-          m_blocked(false) {}
+        : m_index(0)
+        , m_connected(true)
+        , m_blocked(false)
+    {}
 
     virtual ~slot_state() = default;
 
-    bool connected() const noexcept { return m_connected; }
-    bool disconnect() noexcept { return m_connected.exchange(false); }
+    virtual bool connected() const noexcept { return m_connected; }
+
+    bool disconnect() noexcept {
+        bool ret = m_connected.exchange(false);
+        if (ret)
+            do_disconnect();
+        return ret;
+    }
 
     bool blocked() const noexcept { return m_blocked.load(); }
     void block()   noexcept { m_blocked.store(true); }
     void unblock() noexcept { m_blocked.store(false); }
 
+protected:
+    std::size_t m_index;  // index into the array of slot pointers inside the signal
+    virtual void do_disconnect() {}
+
 private:
+    template <typename, typename...>
+    friend class ::sigslot::signal_base;
+
     std::atomic<bool> m_connected;
     std::atomic<bool> m_blocked;
 };
@@ -135,13 +290,13 @@ private:
     connection_blocker(std::weak_ptr<detail::slot_state> s) noexcept
         : m_state{std::move(s)}
     {
-        auto d = m_state.lock();
-        if (d) d->block();
+        if (auto d = m_state.lock())
+            d->block();
     }
 
     void release() noexcept {
-        auto d = m_state.lock();
-        if (d) d->unblock();
+        if (auto d = m_state.lock())
+            d->unblock();
     }
 
 private:
@@ -186,14 +341,12 @@ public:
     }
 
     void block() noexcept {
-        auto d = m_state.lock();
-        if(d)
+        if (auto d = m_state.lock())
             d->block();
     }
 
     void unblock() noexcept {
-        auto d = m_state.lock();
-        if(d)
+        if (auto d = m_state.lock())
             d->unblock();
     }
 
@@ -245,7 +398,14 @@ private:
     {}
 };
 
+
 namespace detail {
+
+// interface for cleanable objects, used to cleanup disconnected slots
+struct cleanable {
+    virtual ~cleanable() = default;
+    virtual void clean(slot_state *) = 0;
+};
 
 template <typename...>
 class slot_base;
@@ -262,6 +422,7 @@ class slot_base : public slot_state {
 public:
     using base_types = trait::typelist<Args...>;
 
+    slot_base(cleanable &c) : cleaner(c) {}
     virtual ~slot_base() = default;
 
     // method effectively responsible for calling the "slot" function with
@@ -274,20 +435,30 @@ public:
             call_slot(std::forward<U>(u)...);
     }
 
-    slot_ptr<Args...> next;
-};
+    std::size_t& index() {
+        return m_index;
+    }
 
-template <typename, typename...> class slot {};
+protected:
+    void do_disconnect() final {
+        cleaner.clean(this);
+    }
+
+private:
+    cleanable &cleaner;
+};
 
 /*
  * A slot object holds state information, and a callable to to be called
  * whenever the function call operator of its slot_base base class is called.
  */
 template <typename Func, typename... Args>
-class slot<Func, trait::typelist<Args...>> : public slot_base<Args...> {
+class slot : public slot_base<Args...> {
 public:
     template <typename F>
-    constexpr slot(F && f) : func{std::forward<F>(f)} {}
+    constexpr slot(cleanable &c, F && f)
+        : slot_base<Args...>(c)
+        , func{std::forward<F>(f)} {}
 
     virtual void call_slot(Args ...args) override {
         func(args...);
@@ -301,10 +472,12 @@ private:
  * Variation of slot that prepends a connection object to the callable
  */
 template <typename Func, typename... Args>
-class slot<Func, trait::typelist<connection&, Args...>> : public slot_base<Args...> {
+class slot_extended : public slot_base<Args...> {
 public:
     template <typename F>
-    constexpr slot(F && f) : func{std::forward<F>(f)} {}
+    constexpr slot_extended(cleanable &c, F && f)
+        : slot_base<Args...>(c)
+        , func{std::forward<F>(f)} {}
 
     virtual void call_slot(Args ...args) override {
         func(conn, args...);
@@ -322,12 +495,13 @@ private:
  * base class is called.
  */
 template <typename Pmf, typename Ptr, typename... Args>
-class slot<Pmf, Ptr, trait::typelist<Args...>> : public slot_base<Args...> {
+class slot_pmf : public slot_base<Args...> {
 public:
     template <typename F, typename P>
-    constexpr slot(F && f, P && p)
-        : pmf{std::forward<F>(f)},
-          ptr{std::forward<P>(p)} {}
+    constexpr slot_pmf(cleanable &c, F && f, P && p)
+        : slot_base<Args...>(c)
+        , pmf{std::forward<F>(f)}
+        , ptr{std::forward<P>(p)} {}
 
     virtual void call_slot(Args ...args) override {
         ((*ptr).*pmf)(args...);
@@ -342,12 +516,13 @@ private:
  * Variation of slot that prepends a connection object to the callable
  */
 template <typename Pmf, typename Ptr, typename... Args>
-class slot<Pmf, Ptr, trait::typelist<connection&, Args...>> : public slot_base<Args...> {
+class slot_pmf_extended : public slot_base<Args...> {
 public:
     template <typename F, typename P>
-    constexpr slot(F && f, P && p)
-        : pmf{std::forward<F>(f)},
-          ptr{std::forward<P>(p)} {}
+    constexpr slot_pmf_extended(cleanable &c, F && f, P && p)
+        : slot_base<Args...>(c)
+        , pmf{std::forward<F>(f)}
+        , ptr{std::forward<P>(p)} {}
 
     virtual void call_slot(Args ...args) override {
         ((*ptr).*pmf)(conn, args...);
@@ -360,28 +535,32 @@ private:
     std::decay_t<Ptr> ptr;
 };
 
-template <typename, typename, typename...> class slot_tracked {};
-
 /*
  * An implementation of a slot that tracks the life of a supplied object
  * through a weak pointer in order to automatically disconnect the slot
  * on said object destruction.
  */
 template <typename Func, typename WeakPtr, typename... Args>
-class slot_tracked<Func, WeakPtr, trait::typelist<Args...>> : public slot_base<Args...> {
+class slot_tracked : public slot_base<Args...> {
 public:
     template <typename F, typename P>
-    constexpr slot_tracked(F && f, P && p)
-        : func{std::forward<F>(f)},
-          ptr{std::forward<P>(p)}
+    constexpr slot_tracked(cleanable &c, F && f, P && p)
+        : slot_base<Args...>(c)
+        , func{std::forward<F>(f)}
+        , ptr{std::forward<P>(p)}
     {}
 
+    bool connected() const noexcept override {
+        return !ptr.expired() && slot_state::connected();
+    }
+
     virtual void call_slot(Args ...args) override {
-        if (! slot_state::connected())
-            return;
-        if (ptr.expired())
+        auto sp = ptr.lock();
+        if (!sp) {
             slot_state::disconnect();
-        else
+            return;
+        }
+        if (slot_state::connected())
             func(args...);
     }
 
@@ -390,49 +569,38 @@ private:
     std::decay_t<WeakPtr> ptr;
 };
 
-template <typename, typename, typename...> class slot_pmf_tracked {};
-
 /*
  * An implementation of a slot as a pointer over member function, that tracks
  * the life of a supplied object through a weak pointer in order to automatically
  * disconnect the slot on said object destruction.
  */
 template <typename Pmf, typename WeakPtr, typename... Args>
-class slot_pmf_tracked<Pmf, WeakPtr, trait::typelist<Args...>> : public slot_base<Args...> {
+class slot_pmf_tracked : public slot_base<Args...> {
 public:
     template <typename F, typename P>
-    constexpr slot_pmf_tracked(F && f, P && p)
-        : pmf{std::forward<F>(f)},
-          ptr{std::forward<P>(p)}
+    constexpr slot_pmf_tracked(cleanable &c, F && f, P && p)
+        : slot_base<Args...>(c)
+        , pmf{std::forward<F>(f)}
+        , ptr{std::forward<P>(p)}
     {}
 
+    bool connected() const noexcept override {
+        return !ptr.expired() && slot_state::connected();
+    }
+
     virtual void call_slot(Args ...args) override {
-        if (! slot_state::connected())
-            return;
         auto sp = ptr.lock();
-        if (!sp)
+        if (!sp) {
             slot_state::disconnect();
-        else
+            return;
+        }
+        if (slot_state::connected())
             ((*sp).*pmf)(args...);
     }
 
 private:
     std::decay_t<Pmf> pmf;
     std::decay_t<WeakPtr> ptr;
-};
-
-
-// noop mutex for thread-unsafe use
-struct null_mutex {
-    null_mutex() = default;
-    null_mutex(const null_mutex &) = delete;
-    null_mutex operator=(const null_mutex &) = delete;
-    null_mutex(null_mutex &&) = delete;
-    null_mutex operator=(null_mutex &&) = delete;
-
-    bool try_lock() { return true; }
-    void lock() {}
-    void unlock() {}
 };
 
 } // namespace detail
@@ -453,9 +621,25 @@ struct null_mutex {
  * @tparam T... the argument types of the emitting and slots functions.
  */
 template <typename Lockable, typename... T>
-class signal_base {
+class signal_base : public detail::cleanable {
+    template <typename L>
+    using is_thread_safe = std::integral_constant<bool, not std::is_same<L, detail::null_mutex>{}>;
+
+    template <typename U, typename L>
+    using cow_type = std::conditional_t<is_thread_safe<L>{}, detail::copy_on_write<U>, U>;
+
+    template <typename U, typename L>
+    using cow_copy_type = std::conditional_t<is_thread_safe<L>{}, detail::copy_on_write<U>, const U&>;
+
     using lock_type = std::unique_lock<Lockable>;
+    using slot_base = detail::slot_base<T...>;
     using slot_ptr = detail::slot_ptr<T...>;
+    using list_type = std::vector<slot_ptr>;
+
+    cow_copy_type<list_type, Lockable> slots_copy() {
+        lock_type lock(m_mutex);
+        return m_slots;
+    }
 
 public:
     using arg_list = trait::typelist<T...>;
@@ -498,30 +682,15 @@ public:
      *
      * @param a... arguments to emit
      */
-    template <typename... A>
-    void operator()(A && ... a) {
-        lock_type lock(m_mutex);
-        slot_ptr *prev = nullptr;
-        slot_ptr *curr = m_slots ? &m_slots : nullptr;
+    void operator()(T ...a) {
+        if (m_block)
+            return;
 
-        while (curr) {
-            // call non blocked, non connected slots
-            if ((*curr)->connected()) {
-                if (!m_block && !(*curr)->blocked())
-                    (*curr)->operator()(std::forward<A>(a)...);
-                prev = curr;
-                curr = (*curr)->next ? &((*curr)->next) : nullptr;
-            }
-            // remove slots marked as disconnected
-            else {
-                if (prev) {
-                    (*prev)->next = (*curr)->next;
-                    curr = (*prev)->next ? &((*prev)->next) : nullptr;
-                }
-                else
-                    curr = (*curr)->next ? &((*curr)->next) : nullptr;
-            }
-        }
+        // copy slots to execute them out of the lock
+        cow_copy_type<list_type, Lockable> copy = slots_copy();
+
+        for (const auto &s : detail::cow_read(copy))
+            s->operator()(a...);
     }
 
     /**
@@ -534,13 +703,14 @@ public:
      * @param c a callable
      * @return a connection object that can be used to interact with the slot
      */
-    template <typename Callable, typename Args = arg_list,
-              std::enable_if_t<trait::is_callable_v<Args, Callable>>* = nullptr>
-    connection connect(Callable && c) {
-        using slot_t = detail::slot<Callable, arg_list>;
-        auto s = std::make_shared<slot_t>(std::forward<Callable>(c));
-        add_slot(s);
-        return connection(s);
+    template <typename Callable>
+    std::enable_if_t<trait::is_callable_v<arg_list, Callable>, connection>
+    connect(Callable && c) {
+        using slot_t = detail::slot<Callable, T...>;
+        auto s = detail::make_shared<slot_base, slot_t>(*this, std::forward<Callable>(c));
+        connection conn(s);
+        add_slot(std::move(s));
+        return conn;
     }
 
     /**
@@ -552,14 +722,15 @@ public:
      * @param c a callable
      * @return a connection object that can be used to interact with the slot
      */
-    template <typename Callable, typename Args = arg_list, typename EArgs = ext_arg_list>
-    std::enable_if_t<!trait::is_callable_v<Args, Callable>, connection>
-    connect(Callable && c) {
-        using slot_t = detail::slot<Callable, EArgs>;
-        auto s = std::make_shared<slot_t>(std::forward<Callable>(c));
-        s->conn = connection(s);
-        add_slot(s);
-        return connection(s);
+    template <typename Callable>
+    std::enable_if_t<trait::is_callable_v<ext_arg_list, Callable>, connection>
+    connect_extended(Callable && c) {
+        using slot_t = detail::slot_extended<Callable, T...>;
+        auto s = detail::make_shared<slot_base, slot_t>(*this, std::forward<Callable>(c));
+        connection conn(s);
+        std::static_pointer_cast<slot_t>(s)->conn = conn;
+        add_slot(std::move(s));
+        return conn;
     }
 
     /**
@@ -569,14 +740,15 @@ public:
      * @param ptr an object pointer
      * @return a connection object that can be used to interact with the slot
      */
-    template <typename Pmf, typename Ptr,
-              std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
-                               !trait::is_weak_ptr_compatible_v<Ptr>>* = nullptr>
-    connection connect(Pmf && pmf, Ptr && ptr) {
-        using slot_t = detail::slot<Pmf, Ptr, arg_list>;
-        auto s = std::make_shared<slot_t>(std::forward<Pmf>(pmf), std::forward<Ptr>(ptr));
-        add_slot(s);
-        return connection(s);
+    template <typename Pmf, typename Ptr>
+    std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
+                     !trait::is_weak_ptr_compatible_v<Ptr>, connection>
+    connect(Pmf && pmf, Ptr && ptr) {
+        using slot_t = detail::slot_pmf<Pmf, Ptr, T...>;
+        slot_ptr s = detail::make_shared<slot_base, slot_t>(*this, std::forward<Pmf>(pmf), std::forward<Ptr>(ptr));
+        connection conn(s);
+        add_slot(std::move(s));
+        return conn;
     }
 
     /**
@@ -586,15 +758,16 @@ public:
      * @param ptr an object pointer
      * @return a connection object that can be used to interact with the slot
      */
-    template <typename Pmf, typename Ptr,
-              std::enable_if_t<trait::is_callable_v<ext_arg_list, Pmf, Ptr> &&
-                               !trait::is_weak_ptr_compatible_v<Ptr>>* = nullptr>
-    connection connect(Pmf && pmf, Ptr && ptr) {
-        using slot_t = detail::slot<Pmf, Ptr, ext_arg_list>;
-        auto s = std::make_shared<slot_t>(std::forward<Pmf>(pmf), std::forward<Ptr>(ptr));
-        s->conn = connection(s);
-        add_slot(s);
-        return connection(s);
+    template <typename Pmf, typename Ptr>
+    std::enable_if_t<trait::is_callable_v<ext_arg_list, Pmf, Ptr> &&
+                     !trait::is_weak_ptr_compatible_v<Ptr>, connection>
+    connect_extended(Pmf && pmf, Ptr && ptr) {
+        using slot_t = detail::slot_pmf_extended<Pmf, Ptr, T...>;
+        auto s = detail::make_shared<slot_base, slot_t>(*this, std::forward<Pmf>(pmf), std::forward<Ptr>(ptr));
+        connection conn(s);
+        std::static_pointer_cast<slot_t>(s)->conn = conn;
+        add_slot(std::move(s));
+        return conn;
     }
 
     /**
@@ -613,16 +786,17 @@ public:
      * @param ptr a trackable object pointer
      * @return a connection object that can be used to interact with the slot
      */
-    template <typename Pmf, typename Ptr,
-              std::enable_if_t<!trait::is_callable_v<arg_list, Pmf> &&
-                               trait::is_weak_ptr_compatible_v<Ptr>>* = nullptr>
-    connection connect(Pmf && pmf, Ptr && ptr) {
+    template <typename Pmf, typename Ptr>
+    std::enable_if_t<!trait::is_callable_v<arg_list, Pmf> &&
+                     trait::is_weak_ptr_compatible_v<Ptr>, connection>
+    connect(Pmf && pmf, Ptr && ptr) {
         using trait::to_weak;
         auto w = to_weak(std::forward<Ptr>(ptr));
-        using slot_t = detail::slot_pmf_tracked<Pmf, decltype(w), arg_list>;
-        auto s = std::make_shared<slot_t>(std::forward<Pmf>(pmf), w);
-        add_slot(s);
-        return connection(s);
+        using slot_t = detail::slot_pmf_tracked<Pmf, decltype(w), T...>;
+        auto s = detail::make_shared<slot_base, slot_t>(*this, std::forward<Pmf>(pmf), w);
+        connection conn(s);
+        add_slot(std::move(s));
+        return conn;
     }
 
     /**
@@ -641,16 +815,17 @@ public:
      * @param ptr a trackable object pointer
      * @return a connection object that can be used to interact with the slot
      */
-    template <typename Callable, typename Trackable,
-              std::enable_if_t<trait::is_callable_v<arg_list, Callable> &&
-                               trait::is_weak_ptr_compatible_v<Trackable>>* = nullptr>
-    connection connect(Callable && c, Trackable && ptr) {
+    template <typename Callable, typename Trackable>
+    std::enable_if_t<trait::is_callable_v<arg_list, Callable> &&
+                     trait::is_weak_ptr_compatible_v<Trackable>, connection>
+    connect(Callable && c, Trackable && ptr) {
         using trait::to_weak;
         auto w = to_weak(std::forward<Trackable>(ptr));
-        using slot_t = detail::slot_tracked<Callable, decltype(w), arg_list>;
-        auto s = std::make_shared<slot_t>(std::forward<Callable>(c), w);
-        add_slot(s);
-        return connection(s);
+        using slot_t = detail::slot_tracked<Callable, decltype(w), T...>;
+        auto s = detail::make_shared<slot_base, slot_t>(*this, std::forward<Callable>(c), w);
+        connection conn(s);
+        add_slot(std::move(s));
+        return conn;
     }
 
     /**
@@ -694,21 +869,41 @@ public:
         return m_block.load();
     }
 
-private:
-    template <typename S>
-    void add_slot(S &s) {
+protected:
+    /**
+     * remove disconnected slots
+     */
+    void clean(detail::slot_state *state) {
         lock_type lock(m_mutex);
-        s->next = m_slots;
-        m_slots = s;
-    }
+        size_t idx = state->m_index;  // must take idx from inside the lock
 
-    void clear() {
-        m_slots.reset();
+        auto &ss = detail::cow_write(m_slots);
+
+        assert(!ss.empty());
+        assert(idx < ss.size());
+        assert(ss[idx].get() == state);
+
+        std::swap(ss[idx], ss.back());
+        ss[idx]->m_index = idx;  // update idx to new position
+        ss.pop_back();
     }
 
 private:
-    slot_ptr m_slots;
+    void add_slot(slot_ptr &&s) {
+        lock_type lock(m_mutex);
+        auto &ss = detail::cow_write(m_slots);
+        s->m_index = ss.size();
+        ss.push_back(std::move(s));
+    }
+
+    // to be called under lock
+    void clear() {
+        detail::cow_write(m_slots).clear();
+    }
+
+private:
     Lockable m_mutex;
+    cow_type<list_type, Lockable> m_slots;
     std::atomic<bool> m_block;
 };
 
@@ -725,21 +920,10 @@ using signal_st = signal_base<detail::null_mutex, T...>;
  * Specialization of signal_base to be used in multi-threaded contexts.
  * Slot connection, disconnection and signal emission are thread-safe.
  *
- * Beware of accidentally using recursive signal emission or cycles between
- * two or more signals in your code. Locking std::mutex more than once is
- * undefined behaviour, even if it "seems to work somehow". Use signal_r
- * instead for that use case.
+ * Recursive signal emission and emission cycles are supported too.
  */
 template <typename... T>
 using signal = signal_base<std::mutex, T...>;
-
-/**
- * Specialization of signal_base to be used in multi-threaded contexts, allowing
- * for recursive signal emission and emission cycles.
- * Slot connection, disconnection and signal emission are thread-safe.
- */
-template <typename... T>
-using signal_r = signal_base<std::recursive_mutex, T...>;
 
 } // namespace sigslot
 


### PR DESCRIPTION
I have addressed the thread safety concerns in my library and just made a new release.

This pull request contains the updated library as well as a few fixes, as several implementations did not compile out of the box under Linux. 

I now check thread safety with additional unit tests exposing the potential deadlocks in recursive emission and other situations. All my tests and examples run cleanly under the address and thread sanitizers in Gcc and Clang.

Also I noticed the neolib library seems to run into a deadlock once every 2 or 3 runs, it may have to be disabled.