### PR TITLE
Test copy count

### DIFF
--- a/results/features.md
+++ b/results/features.md
@@ -9,9 +9,9 @@ This page displays the results of several tests on the features of the signal li
 
 The tests check the behaviour of the library when the signal is activated in various ways, how the connections are handled and what happens when signals are swapped.
 
-The following libraries pass all the tests: bs2, bs2_st, ics.
+None of the tested libraries passes all the tests.
 
-On the tests that could be run (i.e. tests for which the required API is available in the tested library), the following libraries pass all the tests: bs2, bs2_st, ics, ksc, pss.
+On the tests that could be run (i.e. tests for which the required API is available in the tested library), none of the tested libraries passes all the tests.
 
 # Detailed Test results
 
@@ -63,43 +63,44 @@ On the tests that could be run (i.e. tests for which the required API is availab
 ## Activation with argument
 
 1. Can the callbacks have an argument?
-2. Will triggering the signal not make unecessary copies of its argument?
+2. Will triggering the signal with an argument by reference not make unecessary copies of its argument?
+3. Will triggering the signal with an argument by value not make unecessary copies of its argument?
 
- Library |    1    |    2    
----------|---------|---------
- aco     | **yes** | **yes** 
- asg     | **yes** | **yes** 
- bs2     | **yes** | **yes** 
- bs2_st  | **yes** | **yes** 
- cls     | **yes** | **yes** 
- cps     | **yes** | **yes** 
- cps_st  | **yes** | **yes** 
- css     | **yes** | **yes** 
- dob     | **yes** | **yes** 
- evl     | **yes** | **yes** 
- ics     | **yes** | **yes** 
- jls     | **yes** | **yes** 
- jos     | **yes** | **yes** 
- ksc     | **yes** | **yes** 
- lfs     | **yes** | **yes** 
- lss     | **yes** | **yes** 
- mws     | **yes** | **yes** 
- nes     | **yes** | **yes** 
- nls     | **yes** | **yes** 
- nls_st  | **yes** | **yes** 
- nod     | **yes** | **yes** 
- nod_st  | **yes** | **yes** 
- nss_st  | **yes** | **yes** 
- nss_sts | **yes** | **yes** 
- nss_ts  | **yes** | **yes** 
- nss_tss | **yes** | **yes** 
- psg     | **yes** | **yes** 
- pss     | **yes** | **yes** 
- pss_st  | **yes** | **yes** 
- sss     | **yes** | **yes** 
- vdk     | **yes** | **yes** 
- wnk     | **yes** | **yes** 
- yas     | **yes** | **yes** 
+ Library |    1    |    2    |    3    
+---------|---------|---------|---------
+ aco     | **yes** | **yes** |   no    
+ asg     | **yes** | **yes** |   no    
+ bs2     | **yes** | **yes** |   no    
+ bs2_st  | **yes** | **yes** |   no    
+ cls     | **yes** | **yes** |   no    
+ cps     | **yes** | **yes** |   no    
+ cps_st  | **yes** | **yes** |   no    
+ css     | **yes** | **yes** |   no    
+ dob     | **yes** | **yes** |   no    
+ evl     | **yes** | **yes** |   no    
+ ics     | **yes** | **yes** |   no    
+ jls     | **yes** | **yes** |   no    
+ jos     | **yes** | **yes** |   no    
+ ksc     | **yes** | **yes** |   no    
+ lfs     | **yes** | **yes** | **yes** 
+ lss     | **yes** | **yes** |   no    
+ mws     | **yes** | **yes** |   no    
+ nes     | **yes** | **yes** |   no    
+ nls     | **yes** | **yes** |   no    
+ nls_st  | **yes** | **yes** |   no    
+ nod     | **yes** | **yes** |   no    
+ nod_st  | **yes** | **yes** |   no    
+ nss_st  | **yes** | **yes** |   no    
+ nss_sts | **yes** | **yes** |   no    
+ nss_ts  | **yes** | **yes** |   no    
+ nss_tss | **yes** | **yes** |   no    
+ psg     | **yes** | **yes** |   no    
+ pss     | **yes** | **yes** |   no    
+ pss_st  | **yes** | **yes** |   no    
+ sss     | **yes** | **yes** |   no    
+ vdk     | **yes** | **yes** |   no    
+ wnk     | **yes** | **yes** |   no    
+ yas     | **yes** | **yes** |   no    
 
 ## Connection management
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -1,31 +1,7 @@
 /*
-  API issues:
-  - empty() is not implemented.
-  - connection.connect() is not implemented.
-  - recursive access (e.g. connection management during signal execution) hangs.
-  - intrusive connection management.
-  - clear() is not implemented.
-  - swap is not supported.
-  - disconnecting as a member function of the signal (requires to still have
-    access to the signal).
-
-  dob: connection operator bool() is not const.
-  jos: connection's type depends on signals's type.
-  mws: weird namespaces, mw::Signal<> and mw::signals::Connection;
-  nes: painful subscribe syntax. Can't bind lambda? With captures?
-  nls: subscribe return a "handle" which is a private type…
-  nss: needs to implement an observer.
-  psg: signal0, signal1…
-
   Tests to add:
   - connection that outlives the signal.
   - any way to have a signal returning a value?
-
-  Stuff to add in the summary:
-  - a legend,
-  - list the libraries that validate all the tests.
-
-  List the pitch and last update of each library.
  */
 
 #include "tests/hpp/signal_traits_aco.hpp"

--- a/tests.cpp
+++ b/tests.cpp
@@ -96,7 +96,7 @@ public:
 using all_traits =
   testing::Types
   <
-    signal_traits_aco,
+  signal_traits_aco,
     signal_traits_asg,
     signal_traits_bs2,
     signal_traits_bs2_st,
@@ -816,9 +816,10 @@ FENCED_TYPED_TEST
 })
 
 FENCED_TYPED_TEST
-(signal_test, argument_no_copies,
+(signal_test, argument_by_reference_no_copies,
  "Activation with argument",
- "Will triggering the signal not make unecessary copies of its argument?",
+ "Will triggering the signal with an argument by reference not make unecessary"
+ " copies of its argument?",
 {
   struct copy_counter
   {
@@ -856,6 +857,49 @@ FENCED_TYPED_TEST
   
   EXPECT_EQ(0, count_in_callback);
 })
+
+FENCED_TYPED_TEST
+(signal_test, argument_by_value_minimal_copies,
+ "Activation with argument",
+ "Will triggering the signal with an argument by value not make unecessary"
+ " copies of its argument?",
+{
+  struct copy_counter
+  {
+    explicit copy_counter(int* c)
+      : count(c)
+    {}
+
+    copy_counter(const copy_counter& that)
+      : count(that.count)
+    {
+      ++*count;
+    }
+    
+    int* count;
+  };
+
+  static_assert(std::is_move_constructible_v<copy_counter>);
+  static_assert(std::is_move_assignable_v<copy_counter>);
+  
+  using traits = TypeParam;
+  typename traits::template signal<void(copy_counter)> signal;
+
+  int count_in_callback(~0);
+  
+  const typename traits::connection connection
+    (traits::connect
+     (signal,
+      [ &count_in_callback ](copy_counter c) -> void
+      {
+        count_in_callback = *c.count;
+      }));
+
+  int count(0);
+  traits::trigger(signal, copy_counter(&count));
+
+  EXPECT_GE(1, count_in_callback);
+ })
 
 FENCED_TYPED_TEST
 (signal_test, recursive,


### PR DESCRIPTION
These commits add a test in the feature tests in order to ensure that a signal taking its argument by value will make at most one copy of the argument.