### PR TITLE
fix compilation errors when building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,23 +10,33 @@ find_package(Boost COMPONENTS system chrono thread REQUIRED)
 find_package(Threads)
 
 add_library(signal_libraries
-  benchmark/lib/supergrover/sigslot/src/signal.cpp
-  benchmark/lib/jeffomatic/jl_signal/src/SignalBase.cpp
-  benchmark/lib/jeffomatic/jl_signal/src/ObjectPool.cpp
-  benchmark/lib/mwthinker/Signal/src/mw/signals/connection.cpp
-  benchmark/lib/dacap/obs/dacap_connection.cpp
-  benchmark/lib/i42output/src/async_task.cpp
-  benchmark/lib/i42output/src/async_thread.cpp
-  benchmark/lib/i42output/src/event.cpp
-  benchmark/lib/i42output/src/thread.cpp
-  benchmark/lib/i42output/src/timer.cpp
-  benchmark/lib/i42output/src/waitable_event.cpp
-  benchmark/lib/CppFakeIt/libfastsignals/src/lfs_connection.cpp
-  benchmark/lib/CppFakeIt/libfastsignals/src/function_detail.cpp
-  benchmark/lib/CppFakeIt/libfastsignals/src/signal_impl.cpp
-  benchmark/lib/copperspice/cs_signal/src/cs_signal.cpp
-  benchmark/lib/copperspice/cs_signal/src/cs_slot.cpp
-  )
+    benchmark/lib/copperspice/cs_signal/src/cs_signal.cpp
+    benchmark/lib/copperspice/cs_signal/src/cs_slot.cpp
+    benchmark/lib/CppFakeIt/libfastsignals/src/function_detail.cpp
+    benchmark/lib/CppFakeIt/libfastsignals/src/lfs_connection.cpp
+    benchmark/lib/CppFakeIt/libfastsignals/src/signal_impl.cpp
+    benchmark/lib/dacap/obs/dacap_connection.cpp
+    benchmark/lib/i42output/src/async_task.cpp
+    benchmark/lib/i42output/src/async_thread.cpp
+    benchmark/lib/i42output/src/event.cpp
+    benchmark/lib/i42output/src/thread.cpp
+    benchmark/lib/i42output/src/timer.cpp
+    benchmark/lib/i42output/src/waitable_event.cpp
+    benchmark/lib/jeffomatic/jl_signal/src/SignalBase.cpp
+    benchmark/lib/jeffomatic/jl_signal/src/ObjectPool.cpp
+    benchmark/lib/libsigcplusplus/sigc++/connection.cc
+    benchmark/lib/libsigcplusplus/sigc++/functors/slot_base.cc
+    benchmark/lib/libsigcplusplus/sigc++/signal_base.cc
+    benchmark/lib/libsigcplusplus/sigc++/trackable.cc
+    benchmark/lib/mwthinker/Signal/src/mw/signals/connection.cpp
+    benchmark/lib/supergrover/sigslot/src/signal.cpp
+    benchmark/lib/vdksoft/signals/src/signals.cpp
+)
+
+target_include_directories (signal_libraries
+    PUBLIC
+    benchmark/lib/libsigcplusplus
+)
 
 target_link_libraries(signal_libraries iscool_signals)
 

--- a/tests/hpp/signal_traits_vdk.hpp
+++ b/tests/hpp/signal_traits_vdk.hpp
@@ -1,27 +1,28 @@
 #pragma once
 
 #define VDK_SIGNALS_LITE
-#include <vdksoft/signals/include/signals.h>
+#include <vdksoft/signals/src/signals.h>
 
 #include <memory>
 
 struct signal_traits_vdk
 {
-  static constexpr bool has_signal_empty_test = true;
+  static constexpr bool has_signal_empty_test = false;
   static constexpr bool has_connection_connected_test = false;
   static constexpr bool has_disconnect_all = true;
   static constexpr bool has_swap = false;
   static constexpr bool will_deadlock_if_recursively_modified = false;
   static constexpr bool is_intrusive = true;
-  
+
   template<typename Signature>
   using signal = vdk::signal<Signature>;
-  
+
   struct connection_base
   {
     virtual ~connection_base() {}
 
-    virtual bool connected() = 0;
+    // This was removed in the latest vdk version
+    // virtual bool connected() = 0;
     virtual void disconnect() = 0;
   };
 
@@ -30,12 +31,13 @@ struct signal_traits_vdk
   static void initialize() {}
   static void terminate() {}
 
-  template<typename Signal>
-  static bool empty(Signal& s)
-  {
-    return s.empty();
-  }
-  
+//  This was removed in the latest vdk version
+//  template<typename Signal>
+//  static bool empty(Signal& s)
+//  {
+//    return s.empty();
+//  }
+
   template<typename F, typename... Args>
   static connection connect(signal<void(Args...)>& s, F&& f)
   {
@@ -57,7 +59,7 @@ struct signal_traits_vdk
       //{
       //  return m_signal.connected(this, &result_type::call);
       //}
-      
+
       void disconnect() override
       {
         m_signal.disconnect(this, &result_type::call);
@@ -71,7 +73,7 @@ struct signal_traits_vdk
       (std::make_shared<result_type>(s, std::forward<F>(f)));
 
     s.connect(result.get(), &result_type::call);
-    
+
     return result;
   }
 
@@ -86,17 +88,17 @@ struct signal_traits_vdk
   //{
   //  return c->connected();
   //}
-  
+
   template<typename Signal>
   static void disconnect(Signal& s, connection& c)
   {
     c->disconnect();
   }
-  
+
   template<typename Signal>
   static void disconnect_all_slots(Signal& s)
   {
-    s.disconnect_all();
+    s.disconnect();
   }
 };
 


### PR DESCRIPTION
fix compilation errors when building with CMake

In CMakeLists.txt
- added source files for libsigcplusplus and vdksoft
- added include directory for libsigcplusplus

In signal_traits_vdk.hpp
- fixed include directory
- fixed type traits and function names